### PR TITLE
updated brew-cask name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ QuickHue is available through
 cask](https://github.com/phinze/homebrew-cask) is installed.  QuickHue
 can be installed with this command:
 
-`brew cask install quick-hue`
+`brew cask install quickhue`
 
 Features
 ========


### PR DESCRIPTION
The name of the QuickHue cask was recently changed from "quick-hue" to "quickhue", see https://github.com/phinze/homebrew-cask/commits/master/Casks/quickhue.rb
